### PR TITLE
Make logging configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Once we have spot a suspicious activity, we may dig
 deeper by using this information along with the log file to identify the
 particular IP address etc.
 
+## List of available GUC variables:
+
+`pg_auth_mon.log_period` = 60 # dump pg_auth_mon content to Postgres log every 60 minutes (default: 0 meaning the feature is off)
 
 ## How to build and install:
 

--- a/pg_auth_mon.c
+++ b/pg_auth_mon.c
@@ -312,6 +312,8 @@ auth_monitor(Port *port, int status)
 		*last_log_timestamp = now;
 		LWLockRelease(auth_mon_lock);
 		log_pg_auth_mon_data();
+		// prevent double-release of auth_mon_lock
+		return;
 	}
 
 	LWLockRelease(auth_mon_lock);

--- a/pg_auth_mon.c
+++ b/pg_auth_mon.c
@@ -26,6 +26,7 @@
 #include "utils/tuplestore.h"
 #include "utils/timestamp.h"
 #include "utils/acl.h"
+#include "utils/guc.h"
 #include "catalog/pg_authid.h"
 #include "funcapi.h"
 #include "c.h"
@@ -40,6 +41,9 @@ PG_MODULE_MAGIC;
 
 extern void _PG_init(void);
 extern void _PG_fini(void);
+
+/* GUC variables */
+static int pg_auth_mon_log_period_guc = 0;
 
 /* Number of output arguments (columns) for various API versions */
 #define PG_AUTH_MON_COLS_V1_0  6
@@ -122,6 +126,19 @@ _PG_init(void)
 
 	original_client_auth_hook = ClientAuthentication_hook;
 	ClientAuthentication_hook = auth_monitor;
+
+	DefineCustomIntVariable("pg_auth_mon.log_period",
+						"Duration between logging pg_auth_mon data to PG log (in minutes).",
+						NULL,
+						&pg_auth_mon_log_period_guc,
+						0, // 0 means the feature is off
+						0,
+						10080, // one week
+						PGC_SIGHUP,
+						GUC_UNIT_MIN,
+						NULL,
+						NULL,
+						NULL);
 }
 
 /*
@@ -232,7 +249,7 @@ auth_monitor(Port *port, int status)
 				hba_reject = false,
 				fail = false;
 
-	int waittime = 1000 * 60 * 60 * 24; // log at most once in an day
+	int waittime_msec;
 	TimestampTz now = GetCurrentTimestamp();
 
 	/*
@@ -308,7 +325,8 @@ auth_monitor(Port *port, int status)
 		fai->last_successful_login_at = GetCurrentTimestamp();
 	}
 
-	if ((TimestampDifferenceExceeds(*last_log_timestamp, now, waittime))) {
+	waittime_msec = 1000 * 60 * pg_auth_mon_log_period_guc;
+	if (waittime_msec > 0 && (TimestampDifferenceExceeds(*last_log_timestamp, now, waittime_msec))) {
 		*last_log_timestamp = now;
 		LWLockRelease(auth_mon_lock);
 		log_pg_auth_mon_data();

--- a/pg_auth_mon.c
+++ b/pg_auth_mon.c
@@ -43,7 +43,7 @@ extern void _PG_init(void);
 extern void _PG_fini(void);
 
 /* GUC variables */
-static int pg_auth_mon_log_period_guc = 0;
+static int log_period_guc = 0;
 
 /* Number of output arguments (columns) for various API versions */
 #define PG_AUTH_MON_COLS_V1_0  6
@@ -130,7 +130,7 @@ _PG_init(void)
 	DefineCustomIntVariable("pg_auth_mon.log_period",
 						"Duration between logging pg_auth_mon data to PG log (in minutes).",
 						NULL,
-						&pg_auth_mon_log_period_guc,
+						&log_period_guc,
 						0, // 0 means the feature is off
 						0,
 						10080, // one week
@@ -325,8 +325,9 @@ auth_monitor(Port *port, int status)
 		fai->last_successful_login_at = GetCurrentTimestamp();
 	}
 
-	waittime_msec = 1000 * 60 * pg_auth_mon_log_period_guc;
-	if (waittime_msec > 0 && (TimestampDifferenceExceeds(*last_log_timestamp, now, waittime_msec))) {
+	waittime_msec = 1000 * 60 * log_period_guc;
+	if (waittime_msec > 0 && (TimestampDifferenceExceeds(*last_log_timestamp, now, waittime_msec))) 
+	{
 		*last_log_timestamp = now;
 		LWLockRelease(auth_mon_lock);
 		log_pg_auth_mon_data();


### PR DESCRIPTION
1. Fix the bug with the `auth_mon_lock` released twice after logging `pg_auth_mon` data.

`log_pg_auth_mon_data()` acquires and releases the `auth_mon_lock`.   The original PR had [the `return`](https://github.com/RafiaSabih/pg_auth_mon/pull/13/files#diff-b6d96da0f687f3f578be83b08ce801356890648257ca815daf165d0002d3d70eR310) after a call to `log_pg_auth_mon_data()`  to prevent the second [LWLockRelease(auth_mon_lock);](https://github.com/RafiaSabih/pg_auth_mon/pull/13/files#diff-b6d96da0f687f3f578be83b08ce801356890648257ca815daf165d0002d3d70eR313)
This `return` was dropped [during merging](https://github.com/RafiaSabih/pg_auth_mon/commit/d74b591fb4b5359a5df4a6bd678aa0de29612eaa#diff-b6d96da0f687f3f578be83b08ce801356890648257ca815daf165d0002d3d70eR315).

The bug manifest as the inability to connect to a PG server with the following error logged immediately after `pg_auth_mon` data:
```
2021-08-18 14:54:48.366 CEST [152859] FATAL:  lock auth_mon_lock is not held
```
To fix it manually, remove `pg_auth_mon` from `shared_preload_libraries` and restart the PG instance.

2. Introduce the  `pg_auth_mon.log_period` GUC variable to manage the frequency of logging. The value is measured in minutes; only non-negative values up to 10080 (length of one week) are accepted. The value of zero means logging is disabled.